### PR TITLE
Add check for special error from meteor/ddp-rate-limiter

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -187,10 +187,14 @@ AccountsTemplates.submitCallback = function(error, state, onSuccess) {
           AccountsTemplates.state.form.set('error', errorsWithoutField);
         }
       } else {
-        // If error.details is an object, we may try to set fields errors from it
-        _.each(error.details, function(error, fieldId) {
-          AccountsTemplates.getField(fieldId).setError(error);
-        });
+        if (error.error == 'too-many-requests') {
+          AccountsTemplates.state.form.set('error', [error.reason]);
+        } else {
+          // If error.details is an object, we may try to set fields errors from it
+          _.each(error.details, function (error, fieldId) {
+            AccountsTemplates.getField(fieldId).setError(error);
+          });
+        }
       }
     } else {
       var err = 'error.accounts.Unknown error';


### PR DESCRIPTION
Fixes [this issue](https://github.com/meteor-useraccounts/core/issues/629).
Without checking for this error, when rate-limiting kicks in it throws an error because `fieldId` is set to "timeToReset" (and this field does not exist). The whole accounts-form then is disabled and unresponsive, without informing the user about what's going on (you can only see the error message in the client-side browser console).